### PR TITLE
use configure_app and restructure FastAPI deps injection (GDEV-396)

### DIFF
--- a/metadata_repository_service/api/deps.py
+++ b/metadata_repository_service/api/deps.py
@@ -13,19 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Entrypoint of the package"""
+"""FastAPI dependencies (used with the `Depends` feature)"""
 
-from ghga_service_chassis_lib.api import run_server
-
-from .api.main import app  # noqa: F401 pylint: disable=unused-import
-from .config import CONFIG, Config
+from metadata_repository_service.config import CONFIG
 
 
-def run(config: Config = CONFIG):
-    """Run the service"""
-    # Please adapt to package name
-    run_server(app="metadata_repository_service.__main__:app", config=config)
-
-
-if __name__ == "__main__":
-    run()
+def get_config():
+    """Get runtime configuration."""
+    return CONFIG

--- a/metadata_repository_service/api/main.py
+++ b/metadata_repository_service/api/main.py
@@ -20,6 +20,7 @@ Additional endpoints might be structured in dedicated modules
 """
 
 from fastapi import FastAPI
+from ghga_service_chassis_lib.api import configure_app
 
 from metadata_repository_service.api.routers.analyses import analysis_router
 from metadata_repository_service.api.routers.analysis_processes import (
@@ -47,8 +48,11 @@ from metadata_repository_service.api.routers.samples import sample_router
 from metadata_repository_service.api.routers.studies import study_router
 from metadata_repository_service.api.routers.technologies import technology_router
 from metadata_repository_service.api.routers.workflows import workflow_router
+from metadata_repository_service.config import CONFIG
 
 app = FastAPI()
+configure_app(app, config=CONFIG)
+
 app.include_router(dataset_router)
 app.include_router(analysis_router)
 app.include_router(analysis_process_router)

--- a/metadata_repository_service/api/routers/analyses.py
+++ b/metadata_repository_service/api/routers/analyses.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.analysis import get_analysis
 from metadata_repository_service.models import Analysis
 

--- a/metadata_repository_service/api/routers/analysis_processes.py
+++ b/metadata_repository_service/api/routers/analysis_processes.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.analysis_process import get_analysis_process
 from metadata_repository_service.models import AnalysisProcess
 

--- a/metadata_repository_service/api/routers/biospecimens.py
+++ b/metadata_repository_service/api/routers/biospecimens.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.biospecimen import get_biospecimen
 from metadata_repository_service.models import Biospecimen
 

--- a/metadata_repository_service/api/routers/data_access_committees.py
+++ b/metadata_repository_service/api/routers/data_access_committees.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.data_access_committee import (
     get_data_access_committee,
 )

--- a/metadata_repository_service/api/routers/data_access_policies.py
+++ b/metadata_repository_service/api/routers/data_access_policies.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.data_access_policy import get_data_access_policy
 from metadata_repository_service.models import DataAccessPolicy
 

--- a/metadata_repository_service/api/routers/datasets.py
+++ b/metadata_repository_service/api/routers/datasets.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.dataset import get_dataset
 from metadata_repository_service.models import Dataset
 

--- a/metadata_repository_service/api/routers/experiment_processes.py
+++ b/metadata_repository_service/api/routers/experiment_processes.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.experiment_process import get_experiment_process
 from metadata_repository_service.models import ExperimentProcess
 

--- a/metadata_repository_service/api/routers/experiments.py
+++ b/metadata_repository_service/api/routers/experiments.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.experiment import get_experiment
 from metadata_repository_service.models import Experiment
 

--- a/metadata_repository_service/api/routers/files.py
+++ b/metadata_repository_service/api/routers/files.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.file import get_file
 from metadata_repository_service.models import File
 

--- a/metadata_repository_service/api/routers/individuals.py
+++ b/metadata_repository_service/api/routers/individuals.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.individual import get_individual
 from metadata_repository_service.models import Individual
 

--- a/metadata_repository_service/api/routers/members.py
+++ b/metadata_repository_service/api/routers/members.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.member import get_member
 from metadata_repository_service.models import Member
 

--- a/metadata_repository_service/api/routers/projects.py
+++ b/metadata_repository_service/api/routers/projects.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.project import get_project
 from metadata_repository_service.models import Project
 

--- a/metadata_repository_service/api/routers/protocols.py
+++ b/metadata_repository_service/api/routers/protocols.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.protocol import get_protocol
 from metadata_repository_service.models import Protocol
 

--- a/metadata_repository_service/api/routers/publications.py
+++ b/metadata_repository_service/api/routers/publications.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.publication import get_publication
 from metadata_repository_service.models import Publication
 

--- a/metadata_repository_service/api/routers/samples.py
+++ b/metadata_repository_service/api/routers/samples.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.sample import get_sample
 from metadata_repository_service.models import Sample
 

--- a/metadata_repository_service/api/routers/studies.py
+++ b/metadata_repository_service/api/routers/studies.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.study import get_study
 from metadata_repository_service.models import Study
 

--- a/metadata_repository_service/api/routers/technologies.py
+++ b/metadata_repository_service/api/routers/technologies.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.technology import get_technology
 from metadata_repository_service.models import Technology
 

--- a/metadata_repository_service/api/routers/workflows.py
+++ b/metadata_repository_service/api/routers/workflows.py
@@ -17,7 +17,8 @@
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.api.deps import get_config
+from metadata_repository_service.config import Config
 from metadata_repository_service.dao.workflow import get_workflow
 from metadata_repository_service.models import Workflow
 

--- a/metadata_repository_service/config.py
+++ b/metadata_repository_service/config.py
@@ -15,15 +15,12 @@
 
 """Config Parameter Modeling and Parsing"""
 
-from functools import lru_cache
-
 from ghga_service_chassis_lib.api import ApiConfigBase
 from ghga_service_chassis_lib.config import config_from_yaml
-from ghga_service_chassis_lib.pubsub import PubSubConfigBase
 
 
 @config_from_yaml(prefix="metadata_repository_service")
-class Config(ApiConfigBase, PubSubConfigBase):
+class Config(ApiConfigBase):
     """Config parameters and their defaults."""
 
     # config parameter needed for the api server
@@ -34,7 +31,4 @@ class Config(ApiConfigBase, PubSubConfigBase):
     db_name: str = "metadata-store"
 
 
-@lru_cache
-def get_config():
-    """Get runtime configuration."""
-    return Config()
+CONFIG = Config()

--- a/metadata_repository_service/dao/analysis.py
+++ b/metadata_repository_service/dao/analysis.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Analysis records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Analysis
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Analysis
 COLLECTION_NAME = "Analysis"
 
 
-async def retrieve_analyses(config: Config = get_config()) -> List[str]:
+async def retrieve_analyses(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Analysis objects from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_analyses(config: Config = get_config()) -> List[str]:
 
 
 async def get_analysis(
-    analysis_id: str, embedded: bool = False, config: Config = get_config()
+    analysis_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Analysis:
     """
     Given a Datset ID, get the Analysis object from metadata store.
@@ -63,6 +63,6 @@ async def get_analysis(
     collection = client[config.db_name][COLLECTION_NAME]
     analysis = await collection.find_one({"id": analysis_id})  # type: ignore
     if analysis and embedded:
-        analysis = await embed_references(analysis)
+        analysis = await embed_references(analysis, config=config)
     client.close()
     return analysis

--- a/metadata_repository_service/dao/analysis_process.py
+++ b/metadata_repository_service/dao/analysis_process.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving AnalysisProcess records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import AnalysisProcess
@@ -26,7 +26,7 @@ from metadata_repository_service.models import AnalysisProcess
 COLLECTION_NAME = "AnalysisProcess"
 
 
-async def retrieve_analysis_processes(config: Config = get_config()) -> List[str]:
+async def retrieve_analysis_processes(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of AnalysisProcess objects from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_analysis_processes(config: Config = get_config()) -> List[str
 
 
 async def get_analysis_process(
-    analysis_process_id: str, embedded: bool = True, config: Config = get_config()
+    analysis_process_id: str, embedded: bool = True, config: Config = CONFIG
 ) -> AnalysisProcess:
     """
     Given a Datset ID, get the AnalysisProcess object from metadata store.
@@ -63,6 +63,6 @@ async def get_analysis_process(
     collection = client[config.db_name][COLLECTION_NAME]
     analysis_process = await collection.find_one({"id": analysis_process_id})  # type: ignore
     if analysis_process and embedded:
-        analysis_process = await embed_references(analysis_process)
+        analysis_process = await embed_references(analysis_process, config=config)
     client.close()
     return analysis_process

--- a/metadata_repository_service/dao/biospecimen.py
+++ b/metadata_repository_service/dao/biospecimen.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Biospecimen records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Biospecimen
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Biospecimen
 COLLECTION_NAME = "Biospecimen"
 
 
-async def retrieve_biospecimens(config: Config = get_config()) -> List[str]:
+async def retrieve_biospecimens(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Biospecimen object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_biospecimens(config: Config = get_config()) -> List[str]:
 
 
 async def get_biospecimen(
-    biospecimen_id: str, embedded: bool = False, config: Config = get_config()
+    biospecimen_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Biospecimen:
     """
     Given a Datset ID, get the Biospecimen object from metadata store.
@@ -63,6 +63,6 @@ async def get_biospecimen(
     collection = client[config.db_name][COLLECTION_NAME]
     biospecimen = await collection.find_one({"id": biospecimen_id})  # type: ignore
     if biospecimen and embedded:
-        biospecimen = await embed_references(biospecimen)
+        biospecimen = await embed_references(biospecimen, config=config)
     client.close()
     return biospecimen

--- a/metadata_repository_service/dao/data_access_committee.py
+++ b/metadata_repository_service/dao/data_access_committee.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving DataAccessCommittee records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import DataAccessCommittee
@@ -26,7 +26,7 @@ from metadata_repository_service.models import DataAccessCommittee
 COLLECTION_NAME = "DataAccessCommittee"
 
 
-async def retrieve_data_access_committees(config: Config = get_config()) -> List[str]:
+async def retrieve_data_access_committees(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of DataAccessCommittee object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_data_access_committees(config: Config = get_config()) -> List
 
 
 async def get_data_access_committee(
-    data_access_committee_id: str, embedded: bool = False, config: Config = get_config()
+    data_access_committee_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> DataAccessCommittee:
     """
     Given a Datset ID, get the DataAccessCommittee object from metadata store.
@@ -65,6 +65,8 @@ async def get_data_access_committee(
         {"id": data_access_committee_id}
     )  # type: ignore
     if data_access_committee and embedded:
-        data_access_committee = await embed_references(data_access_committee)
+        data_access_committee = await embed_references(
+            data_access_committee, config=config
+        )
     client.close()
     return data_access_committee

--- a/metadata_repository_service/dao/data_access_policy.py
+++ b/metadata_repository_service/dao/data_access_policy.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving DataAccessPolicy records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import DataAccessPolicy
@@ -26,7 +26,7 @@ from metadata_repository_service.models import DataAccessPolicy
 COLLECTION_NAME = "DataAccessPolicy"
 
 
-async def retrieve_data_access_policies(config: Config = get_config()) -> List[str]:
+async def retrieve_data_access_policies(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of DataAccessPolicy object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_data_access_policies(config: Config = get_config()) -> List[s
 
 
 async def get_data_access_policy(
-    data_access_policy_id: str, embedded: bool = False, config: Config = get_config()
+    data_access_policy_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> DataAccessPolicy:
     """
     Given a Datset ID, get the DataAccessPolicy object from metadata store.
@@ -63,6 +63,6 @@ async def get_data_access_policy(
     collection = client[config.db_name][COLLECTION_NAME]
     data_access_policy = await collection.find_one({"id": data_access_policy_id})  # type: ignore
     if data_access_policy and embedded:
-        data_access_policy = await embed_references(data_access_policy)
+        data_access_policy = await embed_references(data_access_policy, config=config)
     client.close()
     return data_access_policy

--- a/metadata_repository_service/dao/dataset.py
+++ b/metadata_repository_service/dao/dataset.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Dataset records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Dataset
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Dataset
 COLLECTION_NAME = "Dataset"
 
 
-async def retrieve_datasets(config: Config = get_config()) -> List[str]:
+async def retrieve_datasets(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Dataset object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_datasets(config: Config = get_config()) -> List[str]:
 
 
 async def get_dataset(
-    dataset_id: str, embedded: bool = False, config: Config = get_config()
+    dataset_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Dataset:
     """
     Given a Datset ID, get the Dataset object from metadata store.
@@ -63,6 +63,6 @@ async def get_dataset(
     collection = client[config.db_name][COLLECTION_NAME]
     dataset = await collection.find_one({"id": dataset_id})  # type: ignore
     if dataset and embedded:
-        dataset = await embed_references(dataset)
+        dataset = await embed_references(dataset, config=config)
     client.close()
     return dataset

--- a/metadata_repository_service/dao/db.py
+++ b/metadata_repository_service/dao/db.py
@@ -17,10 +17,10 @@
 
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 
 
-async def get_db_client(config: Config = get_config()) -> AsyncIOMotorClient:
+async def get_db_client(config: Config = CONFIG) -> AsyncIOMotorClient:
     """
     Get database client.
     """

--- a/metadata_repository_service/dao/experiment.py
+++ b/metadata_repository_service/dao/experiment.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Experiment records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Experiment
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Experiment
 COLLECTION_NAME = "Experiment"
 
 
-async def retrieve_experiments(config: Config = get_config()) -> List[str]:
+async def retrieve_experiments(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Experiment object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_experiments(config: Config = get_config()) -> List[str]:
 
 
 async def get_experiment(
-    experiment_id: str, embedded: bool = False, config: Config = get_config()
+    experiment_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Experiment:
     """
     Given an Experiment ID, get the Experiment object from metadata store.
@@ -63,6 +63,6 @@ async def get_experiment(
     collection = client[config.db_name][COLLECTION_NAME]
     experiment = await collection.find_one({"id": experiment_id})  # type: ignore
     if experiment and embedded:
-        experiment = await embed_references(experiment)
+        experiment = await embed_references(experiment, config=config)
     client.close()
     return experiment

--- a/metadata_repository_service/dao/experiment_process.py
+++ b/metadata_repository_service/dao/experiment_process.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving ExperimentProcess records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import ExperimentProcess
@@ -26,7 +26,7 @@ from metadata_repository_service.models import ExperimentProcess
 COLLECTION_NAME = "ExperimentProcess"
 
 
-async def retrieve_experiment_processes(config: Config = get_config()) -> List[str]:
+async def retrieve_experiment_processes(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of ExperimentProcess object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_experiment_processes(config: Config = get_config()) -> List[s
 
 
 async def get_experiment_process(
-    experiment_process_id: str, embedded: bool = False, config: Config = get_config()
+    experiment_process_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> ExperimentProcess:
     """
     Given a Datset ID, get the ExperimentProcess object from metadata store.
@@ -63,6 +63,6 @@ async def get_experiment_process(
     collection = client[config.db_name][COLLECTION_NAME]
     experiment_process = await collection.find_one({"id": experiment_process_id})  # type: ignore
     if experiment_process and embedded:
-        experiment_process = await embed_references(experiment_process)
+        experiment_process = await embed_references(experiment_process, config=config)
     client.close()
     return experiment_process

--- a/metadata_repository_service/dao/file.py
+++ b/metadata_repository_service/dao/file.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving File records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import File
@@ -26,7 +26,7 @@ from metadata_repository_service.models import File
 COLLECTION_NAME = "File"
 
 
-async def retrieve_files(config: Config = get_config()) -> List[str]:
+async def retrieve_files(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of File object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_files(config: Config = get_config()) -> List[str]:
 
 
 async def get_file(
-    file_id: str, embedded: bool = False, config: Config = get_config()
+    file_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> File:
     """
     Given a Datset ID, get the File object from metadata store.
@@ -63,6 +63,6 @@ async def get_file(
     collection = client[config.db_name][COLLECTION_NAME]
     file = await collection.find_one({"id": file_id})  # type: ignore
     if file and embedded:
-        file = await embed_references(file)
+        file = await embed_references(file, config=config)
     client.close()
     return file

--- a/metadata_repository_service/dao/individual.py
+++ b/metadata_repository_service/dao/individual.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Individual records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Individual
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Individual
 COLLECTION_NAME = "Individual"
 
 
-async def retrieve_individuals(config: Config = get_config()) -> List[str]:
+async def retrieve_individuals(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Individual object IDs from metadata store.
 
@@ -46,7 +46,7 @@ async def retrieve_individuals(config: Config = get_config()) -> List[str]:
 
 
 async def get_individual(
-    individual_id: str, embedded: bool = False, config: Config = get_config()
+    individual_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Individual:
     """
     Given a Datset ID, get the Individual object from metadata store.
@@ -64,6 +64,6 @@ async def get_individual(
     collection = client[config.db_name][COLLECTION_NAME]
     individual = await collection.find_one({"id": individual_id})  # type: ignore
     if individual and embedded:
-        individual = await embed_references(individual)
+        individual = await embed_references(individual, config=config)
     client.close()
     return individual

--- a/metadata_repository_service/dao/member.py
+++ b/metadata_repository_service/dao/member.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Member records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Member
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Member
 COLLECTION_NAME = "Member"
 
 
-async def retrieve_members(config: Config = get_config()) -> List[str]:
+async def retrieve_members(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Member object IDs from metadata store.
 
@@ -46,7 +46,7 @@ async def retrieve_members(config: Config = get_config()) -> List[str]:
 
 
 async def get_member(
-    member_id: str, embedded: bool = False, config: Config = get_config()
+    member_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Member:
     """
     Given a Datset ID, get the Member object from metadata store.
@@ -64,6 +64,6 @@ async def get_member(
     collection = client[config.db_name][COLLECTION_NAME]
     member = await collection.find_one({"id": member_id})  # type: ignore
     if member and embedded:
-        member = await embed_references(member)
+        member = await embed_references(member, config=config)
     client.close()
     return member

--- a/metadata_repository_service/dao/project.py
+++ b/metadata_repository_service/dao/project.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Project records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Project
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Project
 COLLECTION_NAME = "Project"
 
 
-async def retrieve_projects(config: Config = get_config()) -> List[str]:
+async def retrieve_projects(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Project object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_projects(config: Config = get_config()) -> List[str]:
 
 
 async def get_project(
-    project_id: str, embedded: bool = False, config: Config = get_config()
+    project_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Project:
     """
     Given a Datset ID, get the Project object from metadata store.
@@ -63,6 +63,6 @@ async def get_project(
     collection = client[config.db_name][COLLECTION_NAME]
     project = await collection.find_one({"id": project_id})  # type: ignore
     if project and embedded:
-        project = await embed_references(project)
+        project = await embed_references(project, config=config)
     client.close()
     return project

--- a/metadata_repository_service/dao/protocol.py
+++ b/metadata_repository_service/dao/protocol.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Protocol records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Protocol
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Protocol
 COLLECTION_NAME = "Protocol"
 
 
-async def retrieve_protocols(config: Config = get_config()) -> List[str]:
+async def retrieve_protocols(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Protocol object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_protocols(config: Config = get_config()) -> List[str]:
 
 
 async def get_protocol(
-    protocol_id: str, embedded: bool = False, config: Config = get_config()
+    protocol_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Protocol:
     """
     Given an Protocol ID, get the Protocol object from metadata store.
@@ -63,6 +63,6 @@ async def get_protocol(
     collection = client[config.db_name][COLLECTION_NAME]
     protocol = await collection.find_one({"id": protocol_id})  # type: ignore
     if protocol and embedded:
-        protocol = await embed_references(protocol)
+        protocol = await embed_references(protocol, config=config)
     client.close()
     return protocol

--- a/metadata_repository_service/dao/publication.py
+++ b/metadata_repository_service/dao/publication.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Publication records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Publication
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Publication
 COLLECTION_NAME = "Publication"
 
 
-async def retrieve_publications(config: Config = get_config()) -> List[str]:
+async def retrieve_publications(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Publication object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_publications(config: Config = get_config()) -> List[str]:
 
 
 async def get_publication(
-    publication_id: str, embedded: bool = False, config: Config = get_config()
+    publication_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Publication:
     """
     Given a Datset ID, get the Publication object from metadata store.
@@ -63,6 +63,6 @@ async def get_publication(
     collection = client[config.db_name][COLLECTION_NAME]
     publication = await collection.find_one({"id": publication_id})  # type: ignore
     if publication and embedded:
-        publication = await embed_references(publication)
+        publication = await embed_references(publication, config=config)
     client.close()
     return publication

--- a/metadata_repository_service/dao/sample.py
+++ b/metadata_repository_service/dao/sample.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Sample records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Sample
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Sample
 COLLECTION_NAME = "Sample"
 
 
-async def retrieve_samples(config: Config = get_config()) -> List[str]:
+async def retrieve_samples(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Sample object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_samples(config: Config = get_config()) -> List[str]:
 
 
 async def get_sample(
-    sample_id: str, embedded: bool = False, config: Config = get_config()
+    sample_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Sample:
     """
     Given a Datset ID, get the Sample object from metadata store.
@@ -63,6 +63,6 @@ async def get_sample(
     collection = client[config.db_name][COLLECTION_NAME]
     sample = await collection.find_one({"id": sample_id})  # type: ignore
     if sample and embedded:
-        sample = await embed_references(sample)
+        sample = await embed_references(sample, config=config)
     client.close()
     return sample

--- a/metadata_repository_service/dao/study.py
+++ b/metadata_repository_service/dao/study.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Study records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Study
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Study
 COLLECTION_NAME = "Study"
 
 
-async def retrieve_studies(config: Config = get_config()) -> List[str]:
+async def retrieve_studies(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Study object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_studies(config: Config = get_config()) -> List[str]:
 
 
 async def get_study(
-    study_id: str, embedded: bool = False, config: Config = get_config()
+    study_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Study:
     """
     Given a Datset ID, get the Study object from metadata store.
@@ -63,6 +63,6 @@ async def get_study(
     collection = client[config.db_name][COLLECTION_NAME]
     study = await collection.find_one({"id": study_id})  # type: ignore
     if study and embedded:
-        study = await embed_references(study)
+        study = await embed_references(study, config=config)
     client.close()
     return study

--- a/metadata_repository_service/dao/technology.py
+++ b/metadata_repository_service/dao/technology.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Technology records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Technology
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Technology
 COLLECTION_NAME = "Technology"
 
 
-async def retrieve_technologies(config: Config = get_config()) -> List[str]:
+async def retrieve_technologies(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Technology object IDs from metadata store.
 
@@ -45,7 +45,7 @@ async def retrieve_technologies(config: Config = get_config()) -> List[str]:
 
 
 async def get_technology(
-    technology_id: str, embedded: bool = False, config: Config = get_config()
+    technology_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Technology:
     """
     Given an Technology ID, get the Technology object from metadata store.
@@ -63,6 +63,6 @@ async def get_technology(
     collection = client[config.db_name][COLLECTION_NAME]
     technology = await collection.find_one({"id": technology_id})  # type: ignore
     if technology and embedded:
-        technology = await embed_references(technology)
+        technology = await embed_references(technology, config=config)
     client.close()
     return technology

--- a/metadata_repository_service/dao/workflow.py
+++ b/metadata_repository_service/dao/workflow.py
@@ -18,7 +18,7 @@ Convenience methods for retrieving Workflow records
 
 from typing import List
 
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import CONFIG, Config
 from metadata_repository_service.core.utils import embed_references
 from metadata_repository_service.dao.db import get_db_client
 from metadata_repository_service.models import Workflow
@@ -26,7 +26,7 @@ from metadata_repository_service.models import Workflow
 COLLECTION_NAME = "Workflow"
 
 
-async def retrieve_workflows(config: Config = get_config()) -> List[str]:
+async def retrieve_workflows(config: Config = CONFIG) -> List[str]:
     """
     Retrieve a list of Workflow object IDs from metadata store.
 
@@ -43,7 +43,7 @@ async def retrieve_workflows(config: Config = get_config()) -> List[str]:
 
 
 async def get_workflow(
-    workflow_id: str, embedded: bool = False, config: Config = get_config()
+    workflow_id: str, embedded: bool = False, config: Config = CONFIG
 ) -> Workflow:
     """
     Given an Workflow ID, get the Workflow object from metadata store.
@@ -61,6 +61,6 @@ async def get_workflow(
     collection = client[config.db_name][COLLECTION_NAME]
     workflow = await collection.find_one({"id": workflow_id})  # type: ignore
     if workflow and embedded:
-        workflow = await embed_references(workflow)
+        workflow = await embed_references(workflow, config=config)
     client.close()
     return workflow

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    ghga-service-chassis-lib[pubsub,api]==0.4.0
-    motor==2.5.1
+    ghga-service-chassis-lib[api,mongo_connect]==0.8.0
     PyYAML==5.4.1
     stringcase==1.2.0
 python_requires = >= 3.9
@@ -47,24 +46,9 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    pytest
-    pytest-cov
-    mypy
-    pylint
-    black
-    isort
-    bandit
-    flake8
-    pre-commit
-    requests
-    mkdocs
-    mkdocs-material
-    mkdocstrings
-    testcontainers
+    ghga-service-chassis-lib[dev]==0.8.0
     typer
-    pytest-asyncio
-    nest_asyncio
-
+    nest-asyncio
 all =
     %(dev)s
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -20,8 +20,9 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from metadata_repository_service.api.deps import get_config
 from metadata_repository_service.api.main import app
-from metadata_repository_service.config import Config, get_config
+from metadata_repository_service.config import Config
 from tests.fixtures import initialize_test_db  # noqa: F401,F811
 
 nest_asyncio.apply()


### PR DESCRIPTION
Title for squash and merge:
```
use configure_app and restructure FastAPI deps injection (GDEV-396)
```

Description for squash and merge:
```
- use configure_app util from the ghga_service_chassis_lib to correctly configure CORS and more
- restructure default config management:
  - The default config is now available directly in the `CONFIG` variable
  - The `get_config` is moved to `api/deps.py` an should only be used for the FastAPI `Depends` feature
- Fixed python dependencies
```